### PR TITLE
chore: update js-kit getSubdomains getAllDomains to use b64 encoding

### DIFF
--- a/js-kit/src/domain/getAllDomains.ts
+++ b/js-kit/src/domain/getAllDomains.ts
@@ -1,5 +1,6 @@
 import { GetProgramAccountsApi, Rpc } from "@solana/kit";
 
+import { addressCodec, base64Codec } from "../codecs";
 import {
   NAME_PROGRAM_ADDRESS,
   ROOT_DOMAIN_ADDRESS,
@@ -19,7 +20,7 @@ interface GetAllDomainsParams {
 export const getAllDomains = async ({ rpc }: GetAllDomainsParams) => {
   const accounts = await rpc
     .getProgramAccounts(NAME_PROGRAM_ADDRESS, {
-      encoding: "base58",
+      encoding: "base64",
       filters: [
         {
           memcmp: {
@@ -35,6 +36,6 @@ export const getAllDomains = async ({ rpc }: GetAllDomainsParams) => {
 
   return accounts.map(({ account: { data }, pubkey }) => ({
     domainAddress: pubkey,
-    owner: data[0],
+    owner: addressCodec.decode(base64Codec.encode(data[0])),
   }));
 };

--- a/js-kit/src/domain/getSubdomains.ts
+++ b/js-kit/src/domain/getSubdomains.ts
@@ -1,6 +1,6 @@
 import { Address, GetProgramAccountsApi, Rpc } from "@solana/kit";
 
-import { addressCodec, base58Codec } from "../codecs";
+import { addressCodec, base64Codec } from "../codecs";
 import {
   NAME_PROGRAM_ADDRESS,
   REVERSE_LOOKUP_CLASS,
@@ -37,7 +37,7 @@ export const getSubdomains = async ({
 
   const getReversesAsync = rpc
     .getProgramAccounts(NAME_PROGRAM_ADDRESS, {
-      encoding: "base58",
+      encoding: "base64",
       filters: [
         {
           memcmp: {
@@ -59,7 +59,7 @@ export const getSubdomains = async ({
 
   const getSubsAsync = await rpc
     .getProgramAccounts(NAME_PROGRAM_ADDRESS, {
-      encoding: "base58",
+      encoding: "base64",
       filters: [
         {
           memcmp: {
@@ -79,7 +79,7 @@ export const getSubdomains = async ({
     reverses.map((e) => [
       e.pubkey,
       deserializeReverse({
-        data: base58Codec.encode(e.account.data[0]).slice(96),
+        data: base64Codec.encode(e.account.data[0]).slice(96),
         trimFirstNullByte: true,
       }),
     ])
@@ -96,7 +96,7 @@ export const getSubdomains = async ({
           ? {
               subdomain,
               owner: addressCodec.decode(
-                base58Codec.encode(sub.account.data[0])
+                base64Codec.encode(sub.account.data[0])
               ),
             }
           : undefined;


### PR DESCRIPTION
Switch to b64 encoding for all getProgramAccounts calls due to RPC provider constraints.